### PR TITLE
Migrate to standalone project [1/2]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,6 @@
   ],
   "require": {
     "php": ">=5.6",
-    "illuminate/contracts": "5.*",
-    "illuminate/filesystem": "5.*",
     "illuminate/support": "5.*"
   },
   "require-dev": {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace  ArjanSchouten\HtmlMinifier\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace  ArjanSchouten\HtmlMinifier\Exception;
+
+class FileNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+{
+    /**
+     * @param string    $message      Exception message to throw
+     * @param int       $code         Exception code
+     * @param Exception $previous     previous exception used for the exception chaining
+     */
+    public function __construct($message = 'The file does not exists.', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Minifiers/Html/BooleanAttributeMinifier.php
+++ b/src/Minifiers/Html/BooleanAttributeMinifier.php
@@ -18,8 +18,7 @@ class BooleanAttributeMinifier implements MinifierInterface
      */
     public function process(MinifyContext $context)
     {
-        $booleanAttributes = new HtmlBooleanAttributeRepository();
-        $booleanAttributes = implode('|', $booleanAttributes->getAttributes()->all());
+        $booleanAttributes = implode('|', (new HtmlBooleanAttributeRepository())->getAttributes());
 
         return $context->setContents(preg_replace_callback(
             '/

--- a/src/Minifiers/Html/EmptyAttributeMinifier.php
+++ b/src/Minifiers/Html/EmptyAttributeMinifier.php
@@ -54,7 +54,7 @@ class EmptyAttributeMinifier implements MinifierInterface
      */
     private function isBooleanAttribute($attribute)
     {
-        return $this->repository->getAttributes()->search(trim($attribute)) || Html::isDataAttribute($attribute);
+        return array_search(trim($attribute), $this->repository->getAttributes()) || Html::isDataAttribute($attribute);
     }
 
     /**

--- a/src/Placeholders/WhitespacePlaceholder.php
+++ b/src/Placeholders/WhitespacePlaceholder.php
@@ -3,7 +3,6 @@
 namespace ArjanSchouten\HtmlMinifier\Placeholders;
 
 use ArjanSchouten\HtmlMinifier\PlaceholderContainer;
-use ArjanSchouten\HtmlMinifier\Repositories\HtmlInlineElementsRepository;
 
 class WhitespacePlaceholder implements PlaceholderInterface
 {

--- a/src/Repositories/AbstractRepository.php
+++ b/src/Repositories/AbstractRepository.php
@@ -2,8 +2,7 @@
 
 namespace ArjanSchouten\HtmlMinifier\Repositories;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Filesystem\Filesystem;
+use ArjanSchouten\HtmlMinifier\Exception\FileNotFoundException;
 
 abstract class AbstractRepository
 {
@@ -17,23 +16,19 @@ abstract class AbstractRepository
     /**
      * Load a json file and decode it.
      *
-     * @param string $file
+     * @param string $path
      *
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \ArjanSchouten\HtmlMinifier\Exception\FileNotFoundException
      *
      * @return mixed
      */
-    protected function loadJson($file)
+    protected function loadJson($path)
     {
-        $filesystem = new Filesystem();
-
-        if ($filesystem->exists($file)) {
-            $json = $filesystem->get($file);
-
-            return json_decode($json);
+        if (!file_exists($path)) {
+            throw new FileNotFoundException();
         }
 
-        throw new FileNotFoundException();
+        return json_decode(file_get_contents($path));
     }
 
     /**

--- a/src/Repositories/HtmlBooleanAttributeRepository.php
+++ b/src/Repositories/HtmlBooleanAttributeRepository.php
@@ -2,8 +2,6 @@
 
 namespace ArjanSchouten\HtmlMinifier\Repositories;
 
-use Illuminate\Support\Collection;
-
 class HtmlBooleanAttributeRepository extends AbstractRepository
 {
     protected static $attributes;
@@ -11,13 +9,14 @@ class HtmlBooleanAttributeRepository extends AbstractRepository
     /**
      * Get the html boolean attributes.
      *
+     * @throws \ArjanSchouten\HtmlMinifier\Exception\FileNotFoundException
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getAttributes()
     {
         if (self::$attributes === null) {
-            $attributes = $this->loadJson($this->resource('HtmlBooleanAttributes.json'))->attributes;
-            self::$attributes = Collection::make($attributes);
+            self::$attributes = $this->loadJson($this->resource('HtmlBooleanAttributes.json'))->attributes;
         }
 
         return self::$attributes;

--- a/src/Repositories/OptionalElementsRepository.php
+++ b/src/Repositories/OptionalElementsRepository.php
@@ -9,7 +9,7 @@ class OptionalElementsRepository extends AbstractRepository
     /**
      * Get the optional html elments.
      *
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \ArjanSchouten\HtmlMinifier\Exception\FileNotFoundException
      *
      * @return mixed
      */

--- a/tests/Minifiers/EmptyAttributeMinifierTest.php
+++ b/tests/Minifiers/EmptyAttributeMinifierTest.php
@@ -4,7 +4,6 @@ use ArjanSchouten\HtmlMinifier\Minifiers\Html\EmptyAttributeMinifier;
 use ArjanSchouten\HtmlMinifier\Minifiers\Html\HtmlBooleanAttributeRepository;
 use ArjanSchouten\HtmlMinifier\MinifyContext;
 use ArjanSchouten\HtmlMinifier\PlaceholderContainer;
-use Illuminate\Support\Collection;
 use Mockery as m;
 
 class EmptyAttribute extends PHPUnit_Framework_TestCase
@@ -63,7 +62,7 @@ class EmptyAttribute extends PHPUnit_Framework_TestCase
         $context = new MinifyContext(new PlaceholderContainer());
 
         $repository = m::mock(HtmlBooleanAttributeRepository::class)->shouldReceive('getAttributes')->andReturn(
-            new Collection(['async', 'defer'])
+            ['async', 'defer']
         )->getMock();
 
         $this->emptyAttributeMinifier->setRepository($repository);


### PR DESCRIPTION
Hey @ArjanSchouten, sorry for the delay, a bit busier than expected...

Drop `Illuminate\Contracts` and `Illuminate\Filesystem` use (replaced by standalone PHP)

--> There remains only `Illuminate\Support` for now, which I will handle in another PR, I first wanted to know what you think about this one?

`Laravel\Filesystem` has been replaced by custom Exeptions and `file_get_contents()`, even though `SplFileObject` could be used instead, if you prefer?